### PR TITLE
Alteração da ordem de exibição semanal e exemplos de hábitos

### DIFF
--- a/web/src/components/daysweek/DaysWeek.tsx
+++ b/web/src/components/daysweek/DaysWeek.tsx
@@ -3,13 +3,13 @@ import * as S from "./DaysWeek.styles";
 import { useState } from "react";
 
 const availableWeekDays = [
-  "Domingo",
-  "Segunda-feria",
+  "Segunda-feira",
   "Terça-feira",
   "Quarta-feira",
   "Quinta-feira",
   "Sexta-feira",
   "Sabado",
+  "Domingo",
 ];
 
 interface DaysWeekProps {

--- a/web/src/components/newHabitForm/NewHabitForm.tsx
+++ b/web/src/components/newHabitForm/NewHabitForm.tsx
@@ -74,7 +74,7 @@ export function NewHabitForm({ handleClose, open }: INewHabitFormProps) {
           <S.InputBase
             type="text"
             id="title"
-            placeholder="Ex.: Excercícios, dormir bem, etc..."
+            placeholder="Ex.: Atividade física, dormir cedo, meta de hidratação, etc..."
             autoFocus
             value={titles}
             onChange={(event) => setTitle(event.target.value)}


### PR DESCRIPTION
Correção ortográfica da palavrava "segunda-feira".
Alteração da ordem de exibição semanal, onde solicito o início da semana a partir de segunda-feira. 
Alteração de exemplos de hábitos, para facilitar maior entendimento do nosso público alvo.